### PR TITLE
Add Google-style docstrings for clarity

### DIFF
--- a/src/rarapla/config.py
+++ b/src/rarapla/config.py
@@ -1,12 +1,28 @@
-USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0'
+"""Application-wide configuration constants."""
+
+USER_AGENT = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0'
+)
+
+# Proxy settings
 PROXY_HOST = '127.0.0.1'
 PROXY_PORT = 3032
+
+# Network
 HTTP_TIMEOUT = 10
+
+# Window geometry
 WINDOW_MIN_HEIGHT = 400
 WINDOW_DEFAULT_HEIGHT = 720
+
+# Audio
 AUDIO_MIN_VOLUME = 0
 AUDIO_MAX_VOLUME = 100
 AUDIO_DEFAULT_VOLUME = 33
+
+# Radiko proxy parameters
 RADIKO_CACHE_TTL_SEC = 5 * 60
 RADIKO_SEGMENT_RETRY_ATTEMPTS = 3
 RADIKO_CHUNK_SIZE = 64 * 1024

--- a/src/rarapla/data/radiko_client.py
+++ b/src/rarapla/data/radiko_client.py
@@ -1,3 +1,5 @@
+"""Client for fetching program information from Radiko APIs."""
+
 from datetime import datetime, timedelta, timezone
 import re
 import xml.etree.ElementTree as ET
@@ -6,13 +8,21 @@ from rarapla.config import HTTP_TIMEOUT, USER_AGENT
 from rarapla.models.channel import Channel
 from rarapla.models.program import Program
 
-class RadikoClient:
 
-    def __init__(self, session: requests.Session | None=None) -> None:
+class RadikoClient:
+    """Interact with the public Radiko HTTP APIs."""
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        """Create a new client.
+
+        Args:
+            session: Optional preconfigured requests session.
+        """
         self.s: requests.Session = session or requests.Session()
         self.s.headers.update({'User-Agent': USER_AGENT})
 
     def get_area_id(self) -> str:
+        """Return the listener's area identifier."""
         r = self.s.get('https://api.radiko.jp/apparea/area', timeout=HTTP_TIMEOUT)
         r.raise_for_status()
         m = re.search('class="(JP\\d{2})"', r.text)
@@ -21,6 +31,7 @@ class RadikoClient:
         return m.group(1)
 
     def _fetch_station_logos(self, area_id: str) -> dict[str, str]:
+        """Fetch station logo URLs for an area."""
         url = f'https://radiko.jp/v2/station/list/{area_id}.xml'
         r = self.s.get(url, timeout=HTTP_TIMEOUT)
         r.raise_for_status()
@@ -28,12 +39,25 @@ class RadikoClient:
         logos: dict[str, str] = {}
         for st in root.findall('.//station'):
             sid = (st.findtext('id') or '').strip()
-            logo = (st.findtext('logo_medium') or '').strip() or (st.findtext('logo_large') or '').strip() or (st.findtext('logo_small') or '').strip() or (st.findtext('logo_xsmall') or '').strip()
+            logo = (
+                (st.findtext('logo_medium') or '').strip()
+                or (st.findtext('logo_large') or '').strip()
+                or (st.findtext('logo_small') or '').strip()
+                or (st.findtext('logo_xsmall') or '').strip()
+            )
             if sid and logo:
                 logos[sid] = logo
         return logos
 
     def fetch_now_programs(self, area_id: str) -> list[Channel]:
+        """Fetch currently airing programs for all stations in an area.
+
+        Args:
+            area_id: Area identifier returned from :meth:`get_area_id`.
+
+        Returns:
+            List of channels with their current program information.
+        """
         logo_map = self._fetch_station_logos(area_id)
         url = f'http://radiko.jp/v3/program/now/{area_id}.xml'
         r = self.s.get(url, timeout=HTTP_TIMEOUT)
@@ -67,6 +91,14 @@ class RadikoClient:
         return channels
 
     def fetch_program_detail(self, station_id: str) -> Program | None:
+        """Fetch detailed information about the program currently airing.
+
+        Args:
+            station_id: Station identifier.
+
+        Returns:
+            Program details or ``None`` if the API request fails.
+        """
         jst = timezone(timedelta(hours=9))
         now = datetime.now(jst)
         ymd = now.strftime('%Y%m%d')
@@ -75,7 +107,9 @@ class RadikoClient:
         try:
             r = self.s.get(date_url, timeout=HTTP_TIMEOUT)
             if r.status_code == 404:
-                weekly_url = f'https://radiko.jp/v3/program/station/weekly/{station_id}.xml'
+                weekly_url = (
+                    f'https://radiko.jp/v3/program/station/weekly/{station_id}.xml'
+                )
                 rw = self.s.get(weekly_url, timeout=HTTP_TIMEOUT)
                 rw.raise_for_status()
                 root = ET.fromstring(rw.text)
@@ -86,7 +120,10 @@ class RadikoClient:
         except requests.RequestException:
             return None
 
-    def _pick_now_program_from_date(self, root: ET.Element, now_str: str) -> Program | None:
+    def _pick_now_program_from_date(
+        self, root: ET.Element, now_str: str
+    ) -> Program | None:
+        """Pick the program matching ``now_str`` from a date XML."""
         for prog in root.findall('.//prog'):
             ft = prog.get('ft') or ''
             to = prog.get('to') or ''
@@ -94,7 +131,10 @@ class RadikoClient:
                 return self._program_from_xml(prog)
         return None
 
-    def _pick_now_program_from_weekly(self, root: ET.Element, now_str: str, ymd: str) -> Program | None:
+    def _pick_now_program_from_weekly(
+        self, root: ET.Element, now_str: str, ymd: str
+    ) -> Program | None:
+        """Pick the program matching ``now_str`` from a weekly XML."""
         for day in root.findall('.//date'):
             if day.get('yyyymmdd') != ymd:
                 continue
@@ -106,4 +146,10 @@ class RadikoClient:
         return None
 
     def _program_from_xml(self, prog: ET.Element) -> Program:
-        return Program(title=(prog.findtext('title') or '').strip(), pfm=prog.findtext('pfm') or None, desc=prog.findtext('desc') or None, image=prog.findtext('img') or None)
+        """Create a :class:`Program` instance from an XML node."""
+        return Program(
+            title=(prog.findtext('title') or '').strip(),
+            pfm=prog.findtext('pfm') or None,
+            desc=prog.findtext('desc') or None,
+            image=prog.findtext('img') or None,
+        )

--- a/src/rarapla/data/radiko_resolver.py
+++ b/src/rarapla/data/radiko_resolver.py
@@ -1,20 +1,41 @@
+"""Resolve Radiko live stream URLs using Streamlink."""
+
 import requests
 from streamlink import Streamlink
 from rarapla.config import USER_AGENT
 
+
 class ResolvedStream:
+    """Container for a resolved Radiko stream."""
 
     def __init__(self, station_id: str, m3u8_url: str) -> None:
+        """Initialize the stream information.
+
+        Args:
+            station_id: Station identifier.
+            m3u8_url: Direct URL to the master playlist.
+        """
         self.station_id: str = station_id
         self.m3u8_url: str = m3u8_url
 
+
 class RadikoResolver:
+    """Resolve Radiko station IDs into playable stream URLs."""
 
     def __init__(self) -> None:
+        """Create a new resolver with a preconfigured Streamlink session."""
         self._session: Streamlink = Streamlink()
         self._session.set_option('http-headers', {'User-Agent': USER_AGENT})
 
     def resolve_live(self, station_id: str) -> ResolvedStream | None:
+        """Resolve the live stream for a station.
+
+        Args:
+            station_id: Station identifier.
+
+        Returns:
+            The resolved stream information or ``None`` if not available.
+        """
         url = f'https://radiko.jp/#!/live/{station_id}'
         streams = self._session.streams(url)
         stream = streams.get('best')
@@ -24,4 +45,5 @@ class RadikoResolver:
 
     @property
     def http(self) -> requests.Session:
+        """Expose the underlying requests session used by Streamlink."""
         return self._session.http

--- a/src/rarapla/data/radio_browser_client.py
+++ b/src/rarapla/data/radio_browser_client.py
@@ -1,22 +1,70 @@
+"""Client for the Radio Browser API."""
+
 import requests
 from rarapla.models.channel import Channel
 
-class RadioBrowserClient:
 
-    def __init__(self, base: str | None=None, session: requests.Session | None=None) -> None:
+class RadioBrowserClient:
+    """Query stations from the community Radio Browser service."""
+
+    def __init__(
+        self, base: str | None = None, session: requests.Session | None = None
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            base: Base URL of the Radio Browser API.
+            session: Optional requests session to reuse.
+        """
         self.base: str = base or 'https://de1.api.radio-browser.info'
         self.s: requests.Session = session or requests.Session()
         self.s.headers.update({'User-Agent': 'rapla/0.1.0'})
 
-    def search_japan(self, limit: int=100) -> list[Channel]:
-        params = {'countrycode': 'JP', 'hidebroken': 'true', 'order': 'clickcount', 'reverse': 'true', 'limit': str(limit)}
+    def search_japan(self, limit: int = 100) -> list[Channel]:
+        """Search for popular Japanese stations.
+
+        Args:
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of matching channels.
+        """
+        params = {
+            'countrycode': 'JP',
+            'hidebroken': 'true',
+            'order': 'clickcount',
+            'reverse': 'true',
+            'limit': str(limit),
+        }
         return self._search(params)
 
-    def search_by_tag(self, tag: str, limit: int=50) -> list[Channel]:
-        params = {'tag': tag, 'hidebroken': 'true', 'order': 'clickcount', 'reverse': 'true', 'limit': str(limit)}
+    def search_by_tag(self, tag: str, limit: int = 50) -> list[Channel]:
+        """Search stations by a tag.
+
+        Args:
+            tag: Tag name to filter by.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of matching channels.
+        """
+        params = {
+            'tag': tag,
+            'hidebroken': 'true',
+            'order': 'clickcount',
+            'reverse': 'true',
+            'limit': str(limit),
+        }
         return self._search(params)
 
     def notify_click(self, station_uuid: str) -> None:
+        """Notify the API that a station has been clicked.
+
+        Failures are ignored as the call is best-effort.
+
+        Args:
+            station_uuid: UUID of the station.
+        """
         url = f'{self.base}/json/url/{station_uuid}'
         try:
             self.s.get(url, timeout=5)
@@ -24,6 +72,7 @@ class RadioBrowserClient:
             pass
 
     def _search(self, params: dict[str, str]) -> list[Channel]:
+        """Perform a search request against the API."""
         url = f'{self.base}/json/stations/search'
         r = self.s.get(url, params=params, timeout=10)
         r.raise_for_status()
@@ -35,5 +84,14 @@ class RadioBrowserClient:
             fav = (it.get('favicon') or '').strip() or None
             stream = (it.get('url_resolved') or it.get('url') or '').strip()
             if uuid and name and stream:
-                out.append(Channel(id=f'rb:{uuid}', name=name, logo_url=fav, program_title='', program_image=None, stream_url=stream))
+                out.append(
+                    Channel(
+                        id=f'rb:{uuid}',
+                        name=name,
+                        logo_url=fav,
+                        program_title='',
+                        program_image=None,
+                        stream_url=stream,
+                    )
+                )
         return out

--- a/src/rarapla/logging_config.py
+++ b/src/rarapla/logging_config.py
@@ -1,6 +1,20 @@
+"""Logging utilities for the application.
+
+Provides helpers to configure the Python logging module with sane defaults.
+"""
+
 import logging
 
-def setup_logging(level: int=logging.INFO) -> None:
-    logging.basicConfig(level=level, format='%(asctime)s %(levelname)s %(name)s: %(message)s')
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure logging for the application.
+
+    Args:
+        level: Minimum log level to emit.
+    """
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+    )
     logging.getLogger('aiohttp.access').setLevel(logging.WARNING)
     logging.getLogger('qdarkstyle').setLevel(logging.WARNING)

--- a/src/rarapla/models/channel.py
+++ b/src/rarapla/models/channel.py
@@ -1,7 +1,21 @@
+"""Data models for representing radio channels."""
+
 from dataclasses import dataclass
+
 
 @dataclass
 class Channel:
+    """A radio channel currently broadcasting a program.
+
+    Attributes:
+        id: Station identifier.
+        name: Display name for the station.
+        logo_url: URL to the station logo image if available.
+        program_title: Title of the program that is on air.
+        program_image: URL to an image representing the program.
+        stream_url: Direct stream URL when known.
+    """
+
     id: str
     name: str
     logo_url: str | None

--- a/src/rarapla/models/program.py
+++ b/src/rarapla/models/program.py
@@ -1,7 +1,19 @@
+"""Data model for program details."""
+
 from dataclasses import dataclass
+
 
 @dataclass
 class Program:
+    """Details about a radio program.
+
+    Attributes:
+        title: Program title.
+        pfm: Performer or host of the program.
+        desc: Short description of the program.
+        image: URL to an image representing the program.
+    """
+
     title: str
     pfm: str | None = None
     desc: str | None = None

--- a/src/rarapla/proxy/radiko_proxy.py
+++ b/src/rarapla/proxy/radiko_proxy.py
@@ -1,20 +1,45 @@
+"""Lightweight proxy server that rewrites Radiko streams."""
+
 import asyncio
 import os
 import threading
 from urllib.parse import urlencode, urljoin, urlparse
+
 import aiohttp
 from aiohttp import web
-from rarapla.config import HTTP_TIMEOUT, RADIKO_CACHE_TTL_SEC, RADIKO_CHUNK_SIZE, RADIKO_RESOLVE_TTL_SEC, RADIKO_RETRY_DELAY_SEC, RADIKO_SEGMENT_RETRY_ATTEMPTS
+from rarapla.config import (
+    HTTP_TIMEOUT,
+    RADIKO_CACHE_TTL_SEC,
+    RADIKO_CHUNK_SIZE,
+    RADIKO_RESOLVE_TTL_SEC,
+    RADIKO_RETRY_DELAY_SEC,
+    RADIKO_SEGMENT_RETRY_ATTEMPTS,
+)
 from rarapla.data.radiko_resolver import RadikoResolver, ResolvedStream
 
-class RadikoProxyServer:
 
-    def __init__(self, host: str='127.0.0.1', port: int=3032) -> None:
+class RadikoProxyServer:
+    """Proxy Radiko streams and rewrite playlist URLs."""
+
+    def __init__(self, host: str = '127.0.0.1', port: int = 3032) -> None:
+        """Initialize the proxy server.
+
+        Args:
+            host: Hostname to bind.
+            port: TCP port to listen on.
+        """
         self.host: str = host
         self.port: int = port
         self._resolver: RadikoResolver = RadikoResolver()
         self._app: web.Application = web.Application()
-        self._app.add_routes([web.get('/live/{station}.m3u8', self.handle_master), web.get('/seg', self.handle_seg), web.get('/seg.{ext}', self.handle_seg), web.post('/clear_cache', self.handle_clear_cache)])
+        self._app.add_routes(
+            [
+                web.get('/live/{station}.m3u8', self.handle_master),
+                web.get('/seg', self.handle_seg),
+                web.get('/seg.{ext}', self.handle_seg),
+                web.post('/clear_cache', self.handle_clear_cache),
+            ]
+        )
         self._runner: web.AppRunner | None = None
         self._site: web.TCPSite | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -23,20 +48,26 @@ class RadikoProxyServer:
         self._session: aiohttp.ClientSession | None = None
 
     async def handle_master(self, request: web.Request) -> web.Response:
+        """Rewrite the master playlist to point to this proxy."""
         station = request.match_info['station']
         resolved = await self._ensure_resolved(station)
         if not resolved:
             return web.Response(status=404, text='station not found')
         assert self._session is not None
         try:
-            async with self._session.get(resolved.m3u8_url, timeout=HTTP_TIMEOUT) as upstream:
+            async with self._session.get(
+                resolved.m3u8_url, timeout=HTTP_TIMEOUT
+            ) as upstream:
                 if upstream.status != 200:
-                    return web.Response(status=upstream.status, text='upstream error')
+                    return web.Response(
+                        status=upstream.status, text='upstream error'
+                    )
                 text = await upstream.text()
         except asyncio.TimeoutError:
             return web.Response(status=504, text='upstream timeout')
         except aiohttp.ClientError:
             return web.Response(status=502, text='upstream error')
+
         base = self._base_url(resolved.m3u8_url)
         out_lines: list[str] = []
         for line in text.splitlines():
@@ -49,11 +80,22 @@ class RadikoProxyServer:
             ext = os.path.splitext(path)[1].lower().lstrip('.')
             if ext not in ('m3u8', 'aac', 'ts', 'mp3', 'm4a'):
                 ext = 'bin'
-            out_lines.append(f"/seg.{ext}?{urlencode({'u': abs_url, 'station': station})}")
+            out_lines.append(
+                f"/seg.{ext}?{urlencode({'u': abs_url, 'station': station})}"
+            )
         rewritten = '\n'.join(out_lines) + '\n'
-        return web.Response(status=200, text=rewritten, headers={'Content-Type': 'application/vnd.apple.mpegurl', 'Cache-Control': 'no-store, no-cache, must-revalidate', 'Pragma': 'no-cache'})
+        return web.Response(
+            status=200,
+            text=rewritten,
+            headers={
+                'Content-Type': 'application/vnd.apple.mpegurl',
+                'Cache-Control': 'no-store, no-cache, must-revalidate',
+                'Pragma': 'no-cache',
+            },
+        )
 
     async def handle_seg(self, request: web.Request) -> web.StreamResponse:
+        """Proxy an individual segment request."""
         url = request.query.get('u')
         station = request.query.get('station')
         if not url:
@@ -63,10 +105,16 @@ class RadikoProxyServer:
             try:
                 async with self._session.get(url, timeout=HTTP_TIMEOUT) as upstream:
                     if upstream.status == 200:
-                        ctype = upstream.headers.get('Content-Type', 'application/octet-stream')
-                        resp = web.StreamResponse(status=200, headers={'Content-Type': ctype})
+                        ctype = upstream.headers.get(
+                            'Content-Type', 'application/octet-stream'
+                        )
+                        resp = web.StreamResponse(
+                            status=200, headers={'Content-Type': ctype}
+                        )
                         await resp.prepare(request)
-                        async for chunk in upstream.content.iter_chunked(RADIKO_CHUNK_SIZE):
+                        async for chunk in upstream.content.iter_chunked(
+                            RADIKO_CHUNK_SIZE
+                        ):
                             if chunk:
                                 await resp.write(chunk)
                         await resp.write_eof()
@@ -74,19 +122,26 @@ class RadikoProxyServer:
                     elif upstream.status == 403 and station:
                         self._cache.pop(station, None)
                         import asyncio as _asyncio
+
                         await _asyncio.sleep(0.15)
                         resolved = await self._ensure_resolved(station)
                         if resolved:
                             old_parsed = urlparse(url)
                             filename = old_parsed.path.split('/')[-1]
-                            tail = filename + (f'?{old_parsed.query}' if old_parsed.query else '')
+                            tail = filename + (
+                                f'?{old_parsed.query}' if old_parsed.query else ''
+                            )
                             new_base = self._base_url(resolved.m3u8_url)
                             url = f'{new_base}{tail}'
                             continue
                         else:
-                            return web.Response(status=503, text='failed to resolve stream')
+                            return web.Response(
+                                status=503, text='failed to resolve stream'
+                            )
                     else:
-                        return web.Response(status=upstream.status, text='upstream error')
+                        return web.Response(
+                            status=upstream.status, text='upstream error'
+                        )
             except (asyncio.TimeoutError, aiohttp.ClientError):
                 if attempt < RADIKO_SEGMENT_RETRY_ATTEMPTS - 1:
                     if station:
@@ -96,6 +151,7 @@ class RadikoProxyServer:
         return web.Response(status=502, text='all attempts failed')
 
     async def handle_clear_cache(self, request: web.Request) -> web.Response:
+        """Clear cached stream resolutions for a station."""
         try:
             data = await request.json()
             station = data.get('station')
@@ -107,12 +163,15 @@ class RadikoProxyServer:
         return web.Response(status=400, text='invalid request')
 
     def _base_url(self, url: str) -> str:
+        """Return the directory portion of a URL."""
         p = urlparse(url)
         base_path = p.path.rsplit('/', 1)[0]
         return f'{p.scheme}://{p.netloc}{base_path}/'
 
     async def _ensure_resolved(self, station: str) -> ResolvedStream | None:
+        """Resolve and cache stream information for a station."""
         import time
+
         now = time.monotonic()
         cached = self._cache.get(station)
         ttl = RADIKO_RESOLVE_TTL_SEC
@@ -123,22 +182,27 @@ class RadikoProxyServer:
             else:
                 self._cache.pop(station, None)
         await asyncio.sleep(RADIKO_RETRY_DELAY_SEC)
-        new_res: ResolvedStream | None = await asyncio.to_thread(self._resolver.resolve_live, station)
+        new_res: ResolvedStream | None = await asyncio.to_thread(
+            self._resolver.resolve_live, station
+        )
         if new_res:
             self._cache[station] = (new_res, now)
         return new_res
 
     def start_in_thread(self) -> None:
+        """Start the proxy server on a dedicated thread."""
 
         def runner() -> None:
             self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
             self._loop.run_until_complete(self._start())
             self._loop.run_forever()
+
         t: threading.Thread = threading.Thread(target=runner, daemon=True)
         t.start()
 
     async def _start(self) -> None:
+        """Start the aiohttp server and client session."""
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
         self._site = web.TCPSite(self._runner, self.host, self.port)
@@ -155,10 +219,12 @@ class RadikoProxyServer:
         self._session = aiohttp.ClientSession(timeout=timeout, headers=base)
 
     def stop(self) -> None:
+        """Request graceful shutdown of the proxy server."""
         if self._loop:
             self._loop.call_soon_threadsafe(asyncio.create_task, self._shutdown())
 
     async def _shutdown(self) -> None:
+        """Shut down the aiohttp server and release resources."""
         if self._site:
             await self._site.stop()
         if self._runner:


### PR DESCRIPTION
## Summary
- document configuration settings and major classes using Google-style docstrings
- clarify Radiko proxy and client modules with descriptive comments and structured docstrings

## Testing
- `pytest`
- `flake8 src/rarapla/data/radiko_client.py src/rarapla/proxy/radiko_proxy.py src/rarapla/logging_config.py src/rarapla/models/channel.py src/rarapla/models/program.py src/rarapla/data/radiko_resolver.py src/rarapla/data/radio_browser_client.py src/rarapla/config.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7182bc1a883299ee5ee6c6f8447ac