### PR TITLE
Refactor code to satisfy linters

### DIFF
--- a/src/rarapla/__main__.py
+++ b/src/rarapla/__main__.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from textwrap import dedent
+
 from PySide6.QtCore import (
     QLoggingCategory,
     QMessageLogContext,
@@ -41,7 +43,16 @@ def main() -> None:
     font = QFont("Meiryo UI", 10)
     app.setFont(font)
     QLoggingCategory.setFilterRules(
-        "qt.multimedia.debug=false\nqt.multimedia.info=false\nqt.multimedia.warning=false\nqt.multimedia.ffmpeg.debug=false\nqt.multimedia.ffmpeg.info=false\nqt.multimedia.ffmpeg.warning=false\n"
+        "\n".join(
+            [
+                "qt.multimedia.debug=false",
+                "qt.multimedia.info=false",
+                "qt.multimedia.warning=false",
+                "qt.multimedia.ffmpeg.debug=false",
+                "qt.multimedia.ffmpeg.info=false",
+                "qt.multimedia.ffmpeg.warning=false",
+            ]
+        )
     )
     qInstallMessageHandler(_qt_msg_filter)
     try:
@@ -50,7 +61,53 @@ def main() -> None:
         base = qdarkstyle.load_stylesheet()
         app.setStyleSheet(
             base
-            + '\n            /* QListWidget のデフォルト矩形ハイライトを消す */\n            QListWidget::item:selected {\n                background: transparent;\n            }\n\n            /* 通常は枠のみ（完全透明） */\n            #ChannelCard {\n                border: 1px solid rgba(255,255,255,0.18);\n                border-radius: 4px;\n                background: transparent;\n            }\n\n            /* hover */\n            #ChannelCard:hover {\n                border-color: rgba(255,255,255,0.30);\n                background: rgba(255,255,255,0.04);\n            }\n\n            /* ダイナミックプロパティ selected=true のときだけ色を付ける */\n            #ChannelCard[selected="true"] {\n                border-color: #3daee9;\n                background: rgba(61,174,233,0.2);\n            }\n\n            /* ラベルは透過（ロゴ・文字の四角防止） */\n            #ChannelCard QLabel {\n                background: transparent;\n            }\n\n            #ChannelCard QLabel#ChannelIcon {\n                background: white;\n                border-radius: 4px;\n            }\n\n            /* タイトルを太字・大きめ */\n            #ChannelCard #ChannelName {\n                font-weight: bold;\n                font-size: 14pt;\n            }\n            #DetailTitle {\n                font-weight: bold;\n                font-size: 14pt;\n            }\n            '
+            + dedent(
+                """
+                /* QListWidget のデフォルト矩形ハイライトを消す */
+                QListWidget::item:selected {
+                    background: transparent;
+                }
+
+                /* 通常は枠のみ（完全透明） */
+                #ChannelCard {
+                    border: 1px solid rgba(255,255,255,0.18);
+                    border-radius: 4px;
+                    background: transparent;
+                }
+
+                /* hover */
+                #ChannelCard:hover {
+                    border-color: rgba(255,255,255,0.30);
+                    background: rgba(255,255,255,0.04);
+                }
+
+                /* ダイナミックプロパティ selected=true のときだけ色を付ける */
+                #ChannelCard[selected="true"] {
+                    border-color: #3daee9;
+                    background: rgba(61,174,233,0.2);
+                }
+
+                /* ラベルは透過（ロゴ・文字の四角防止） */
+                #ChannelCard QLabel {
+                    background: transparent;
+                }
+
+                #ChannelCard QLabel#ChannelIcon {
+                    background: white;
+                    border-radius: 4px;
+                }
+
+                /* タイトルを太字・大きめ */
+                #ChannelCard #ChannelName {
+                    font-weight: bold;
+                    font-size: 14pt;
+                }
+                #DetailTitle {
+                    font-weight: bold;
+                    font-size: 14pt;
+                }
+                """
+            )
         )
     except Exception:
         pass

--- a/src/rarapla/services/icy_watcher.py
+++ b/src/rarapla/services/icy_watcher.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import QObject, QThread, Signal
 import asyncio
 import aiohttp
+from collections.abc import Mapping
 from urllib.parse import parse_qs, unquote_plus
 
 
@@ -19,7 +20,7 @@ class IcyWatcher(QThread):
         self._last_title = ""
         self._base_meta: dict[str, str] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[None] | None = None
         self._session: aiohttp.ClientSession | None = None
         self._resp: aiohttp.ClientResponse | None = None
 
@@ -168,7 +169,9 @@ class IcyWatcher(QThread):
                 pass
         return ""
 
-    def _parse_metadata_text(self, text: str, station: str) -> tuple[str, dict]:
+    def _parse_metadata_text(
+        self, text: str, station: str
+    ) -> tuple[str, dict[str, str]]:
         items: dict[str, str] = {}
         for part in text.split(";"):
             part = part.strip()
@@ -198,17 +201,5 @@ class IcyWatcher(QThread):
                 pass
         return (title, meta_map)
 
-    def _extract_headers(self, hdr) -> dict[str, str]:
+    def _extract_headers(self, hdr: Mapping[str, str]) -> dict[str, str]:
         return {str(k): str(v) for k, v in hdr.items()}
-
-    def _parse_metadata_text(self, text: str, station: str) -> tuple[str, dict]:
-        items: dict[str, str] = {}
-        for part in text.split(";"):
-            part = part.strip()
-            if not part or "=" not in part:
-                continue
-            k, v = part.split("=", 1)
-            v = v.strip().strip("'").strip('"')
-            items[k.strip()] = v
-        title = items.get("StreamTitle", "").strip()
-        return (title, items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import asyncio
 from collections.abc import Coroutine, Mapping
 from datetime import datetime, timedelta, timezone, tzinfo
+from textwrap import dedent
 from typing import Any, TypeVar
+
 import pytest
 
 
 class FakeResponse:
-
     def __init__(self, status_code: int = 200, text: str = "") -> None:
         self.status_code = status_code
         self.text = text
@@ -19,7 +20,6 @@ class FakeResponse:
 
 
 class FakeRequestsSession:
-
     def __init__(self, table: Mapping[str, FakeResponse]) -> None:
         self._table = dict(table)
         self.headers: dict[str, str] = {}
@@ -32,7 +32,6 @@ class FakeRequestsSession:
 
 
 class _FakeAiohttpResp:
-
     def __init__(self, status: int = 200, text: str = "") -> None:
         self.status = status
         self._text = text
@@ -51,7 +50,6 @@ class _FakeAiohttpResp:
 
 
 class FakeAiohttpSession:
-
     def __init__(self, text: str = "") -> None:
         self._text = text
 
@@ -66,26 +64,94 @@ def sample_area_html() -> str:
 
 @pytest.fixture
 def station_list_xml() -> str:
-    return '<?xml version="1.0" encoding="UTF-8"?>\n<stations>\n  <station>\n    <id>FMT</id>\n    <name>FM TOKYO</name>\n    <logo_medium>http://cdn/logo_fmt_med.png</logo_medium>\n    <logo_small>http://cdn/logo_fmt_small.png</logo_small>\n  </station>\n  <station>\n    <id>TBS</id>\n    <name>TBS RADIO</name>\n    <logo_large>http://cdn/logo_tbs_large.png</logo_large>\n  </station>\n</stations>\n'
+    return dedent(
+        """\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <stations>
+          <station>
+            <id>FMT</id>
+            <name>FM TOKYO</name>
+            <logo_medium>http://cdn/logo_fmt_med.png</logo_medium>
+            <logo_small>http://cdn/logo_fmt_small.png</logo_small>
+          </station>
+          <station>
+            <id>TBS</id>
+            <name>TBS RADIO</name>
+            <logo_large>http://cdn/logo_tbs_large.png</logo_large>
+          </station>
+        </stations>
+        """
+    )
 
 
 @pytest.fixture
 def now_xml_current_hit() -> str:
-    return '<?xml version="1.0" encoding="UTF-8"?>\n<radiko>\n  <station id="FMT">\n    <name>FM TOKYO</name>\n    <progs>\n      <prog ft="20250102110000" to="20250102125959">\n        <title>NOW-HIT</title>\n        <img>http://img/now_fmt.png</img>\n      </prog>\n      <prog ft="20250102130000" to="20250102135959">\n        <title>NEXT</title>\n      </prog>\n    </progs>\n  </station>\n  <station id="TBS">\n    <name>TBS RADIO</name>\n    <progs>\n      <prog ft="20250102120000" to="20250102125959">\n        <title>TBS-NOW</title>\n      </prog>\n    </progs>\n  </station>\n</radiko>\n'
+    return dedent(
+        """\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <radiko>
+          <station id="FMT">
+            <name>FM TOKYO</name>
+            <progs>
+              <prog ft="20250102110000" to="20250102125959">
+                <title>NOW-HIT</title>
+                <img>http://img/now_fmt.png</img>
+              </prog>
+              <prog ft="20250102130000" to="20250102135959">
+                <title>NEXT</title>
+              </prog>
+            </progs>
+          </station>
+          <station id="TBS">
+            <name>TBS RADIO</name>
+            <progs>
+              <prog ft="20250102120000" to="20250102125959">
+                <title>TBS-NOW</title>
+              </prog>
+            </progs>
+          </station>
+        </radiko>
+        """
+    )
 
 
 @pytest.fixture
 def date_xml_has_now() -> str:
-    return '<?xml version="1.0" encoding="UTF-8"?>\n<root>\n  <prog ft="20250102110000" to="20250102125959">\n    <title>DateAPI Program</title>\n    <pfm>Aさん, Bさん</pfm>\n    <desc>説明テキスト</desc>\n    <img>http://img/date.png</img>\n  </prog>\n</root>\n'
+    return dedent(
+        """\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <root>
+          <prog ft="20250102110000" to="20250102125959">
+            <title>DateAPI Program</title>
+            <pfm>Aさん, Bさん</pfm>
+            <desc>説明テキスト</desc>
+            <img>http://img/date.png</img>
+          </prog>
+        </root>
+        """
+    )
 
 
 @pytest.fixture
 def weekly_xml_fallback() -> str:
-    return '<?xml version="1.0" encoding="UTF-8"?>\n<root>\n  <date yyyymmdd="20250102">\n    <prog ft="20250102110000" to="20250102125959">\n      <title>WeeklyAPI Program</title>\n      <pfm>Cさん</pfm>\n      <desc>週次説明</desc>\n      <img>http://img/weekly.png</img>\n    </prog>\n  </date>\n</root>\n'
+    return dedent(
+        """\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <root>
+          <date yyyymmdd="20250102">
+            <prog ft="20250102110000" to="20250102125959">
+              <title>WeeklyAPI Program</title>
+              <pfm>Cさん</pfm>
+              <desc>週次説明</desc>
+              <img>http://img/weekly.png</img>
+            </prog>
+          </date>
+        </root>
+        """
+    )
 
 
 class FakeDateTime(datetime):
-
     @classmethod
     def now(cls, tz: tzinfo | None = None) -> "FakeDateTime":
         jst = timezone(timedelta(hours=9))


### PR DESCRIPTION
## Summary
- replace hard-coded Qt settings with multiline strings
- clean up ICY watcher type hints and metadata parsing
- streamline test XML fixtures

## Testing
- `flake8`
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71e5230308329b785d758995592fb