### PR TITLE
Add fallback port selection for local proxy

### DIFF
--- a/src/rarapla/app.py
+++ b/src/rarapla/app.py
@@ -118,7 +118,7 @@ def main() -> None:
     app.setPalette(pal)
     proxy = RadikoProxyServer(host=PROXY_HOST, port=PROXY_PORT)
     proxy.start_in_thread()
-    w = MainWindow(proxy_host=PROXY_HOST, proxy_port=PROXY_PORT)
+    w = MainWindow(proxy_host=PROXY_HOST, proxy_port=proxy.port)
     w.show()
     code = app.exec()
     proxy.stop()

--- a/tests/test_proxy_port_selection.py
+++ b/tests/test_proxy_port_selection.py
@@ -1,0 +1,11 @@
+import socket
+from rarapla.config import PROXY_PORT
+from rarapla.proxy.radiko_proxy import RadikoProxyServer
+
+
+def test_default_port_fallback() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", PROXY_PORT))
+        s.listen()
+        proxy = RadikoProxyServer()
+        assert proxy.port == PROXY_PORT + 1


### PR DESCRIPTION
## Summary
- auto-select free port starting at 3032 for Radiko proxy
- pass actual proxy port to UI
- test proxy port fallback behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82d8da5808329989dfb60294a9672