### PR TITLE
Ensure safe shutdown on window close

### DIFF
--- a/src/rarapla/ui/controllers/now_refresher.py
+++ b/src/rarapla/ui/controllers/now_refresher.py
@@ -26,6 +26,19 @@ class NowRefresher(QObject):
     def stop(self) -> None:
         self._timer.stop()
 
+    def shutdown(self) -> None:
+        self.stop()
+        t = self._thread
+        if t is not None:
+            t.quit()
+            t.wait(3000)
+            t.deleteLater()
+            self._thread = None
+        if self._worker is not None:
+            self._worker.deleteLater()
+            self._worker = None
+        self._busy = False
+
     def _tick(self) -> None:
         if self._busy or self._thread is not None:
             return

--- a/src/rarapla/ui/controllers/playback_controller.py
+++ b/src/rarapla/ui/controllers/playback_controller.py
@@ -58,6 +58,15 @@ class PlaybackController(QObject):
             self.player.set_media(self._current_direct_url)
             self.player.svc.play()
 
+    def shutdown(self) -> None:
+        self._refresh_timer.stop()
+        self._stop_icy_watch()
+        try:
+            self.player.svc.stop()
+            self.player.svc.clear_source()
+        except Exception:
+            pass
+
     def _build_local_m3u8(self, station_id: str, force: bool = False) -> str:
         base = f"{self.proxy_base}/live/{station_id}.m3u8"
         if force:


### PR DESCRIPTION
## Summary
- add shutdown support to background refresh controller
- clean up playback resources on shutdown
- close window safely by stopping timers, workers, and threads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8300bb2108329adecb52be633af90