### PR TITLE
Add explicit type hints across UI modules

### DIFF
--- a/src/rarapla/ui/controllers/now_refresher.py
+++ b/src/rarapla/ui/controllers/now_refresher.py
@@ -1,5 +1,6 @@
 from PySide6.QtCore import QObject, QThread, QTimer, Signal
 from rarapla.data.radiko_client import RadikoClient
+from rarapla.models.channel import Channel
 from rarapla.ui.workers.channel_fetch_worker import ChannelFetchWorker
 from rarapla.config import NOW_REFRESH_INTERVAL_MS
 
@@ -48,7 +49,7 @@ class NowRefresher(QObject):
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.run)
 
-        def _done(chs: list) -> None:
+        def _done(chs: list[Channel]) -> None:
             self.updated.emit(chs)
             self._thread.quit()
 

--- a/src/rarapla/ui/controllers/playback_controller.py
+++ b/src/rarapla/ui/controllers/playback_controller.py
@@ -6,7 +6,7 @@ from rarapla.services.icy_watcher import IcyWatcher
 
 
 class PlaybackController(QObject):
-    streamTitleChanged = Signal(str, object)
+    streamTitleChanged = Signal(str, dict)
     playbackError = Signal(str)
 
     def __init__(self, player: PlayerWidget, proxy_base: str) -> None:
@@ -161,7 +161,7 @@ class PlaybackController(QObject):
         self._icy.wait(3000)
         self._icy = None
 
-    def _on_icy_meta(self, title: str, meta: dict) -> None:
+    def _on_icy_meta(self, title: str, meta: dict[str, str]) -> None:
         self.streamTitleChanged.emit(title, meta)
 
     def _on_icy_not_supported(self, reason: str) -> None:

--- a/src/rarapla/ui/workers/program_fetch_worker.py
+++ b/src/rarapla/ui/workers/program_fetch_worker.py
@@ -4,7 +4,7 @@ from rarapla.models.channel import Channel
 
 
 class ProgramFetchWorker(QObject):
-    finished = Signal(object, object)
+    finished = Signal(Channel, object)
     error = Signal(str)
     cancelled = Signal()
 


### PR DESCRIPTION
## Summary
- add explicit type annotations for radio channel handling in `MainWindow`
- type `NowRefresher` and `PlaybackController` internal helpers
- specify channel type in `ProgramFetchWorker` signal

## Testing
- `pytest`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68abaf6777888329a7aae2b81c0f300c