### PR TITLE
Fix mypy instantiation errors and adjust proxy typing

### DIFF
--- a/src/rarapla/data/radiko_resolver.py
+++ b/src/rarapla/data/radiko_resolver.py
@@ -1,7 +1,7 @@
 """Resolve Radiko live stream URLs using Streamlink."""
 
 import requests
-from streamlink import Streamlink
+from streamlink import Streamlink  # type: ignore[attr-defined]
 from rarapla.config import USER_AGENT
 
 

--- a/src/rarapla/ui/main_window.py
+++ b/src/rarapla/ui/main_window.py
@@ -92,8 +92,8 @@ class MainWindow(QMainWindow):
         self._rb_thread: QThread | None = None
         self._rb_worker: RBSearchWorker | None = None
         self._item_by_id: dict[str, QListWidgetItem] = {}
-        self._pending_channel = None
-        self._current_channel = None
+        self._pending_channel: Channel | None = None
+        self._current_channel: Channel | None = None
         self._build_ui()
         self._connect_signals()
         self.playback = PlaybackController(self.player, self.proxy_base)

--- a/src/rarapla/ui/widgets/smooth_area.py
+++ b/src/rarapla/ui/widgets/smooth_area.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 from PySide6.QtGui import QWheelEvent
 from PySide6.QtWidgets import QScrollArea, QWidget
 
 if TYPE_CHECKING:
 
-    class SmoothScrollMixin(Protocol):
+    class SmoothScrollMixin:
         def _smooth_wheel_event(self, e: QWheelEvent) -> None: ...
 
 else:

--- a/src/rarapla/ui/widgets/smooth_list.py
+++ b/src/rarapla/ui/widgets/smooth_list.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 from PySide6.QtGui import QWheelEvent
 from PySide6.QtWidgets import QAbstractItemView, QListWidget, QWidget
 
 if TYPE_CHECKING:
 
-    class SmoothScrollMixin(Protocol):
+    class SmoothScrollMixin:
         def _smooth_wheel_event(self, e: QWheelEvent) -> None: ...
 
 else:


### PR DESCRIPTION
## Summary
- avoid abstract class instantiation in smooth scrolling widgets
- annotate optional channel state in the main window
- clean up Radiko proxy types and Streamlink import

## Testing
- `mypy .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abe5dc45f48329be4a62b88b0b766b