### PR TITLE
Add file logging option and detailed format

### DIFF
--- a/src/rarapla/logging_config.py
+++ b/src/rarapla/logging_config.py
@@ -6,15 +6,21 @@ Provides helpers to configure the Python logging module with sane defaults.
 import logging
 
 
-def setup_logging(level: int = logging.INFO) -> None:
+def setup_logging(level: int = logging.INFO, log_file: str | None = None) -> None:
     """Configure logging for the application.
 
     Args:
         level: Minimum log level to emit.
+        log_file: Optional path of a file to also receive log output.
     """
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    if log_file is not None:
+        handlers.append(logging.FileHandler(log_file, encoding="utf-8"))
     logging.basicConfig(
         level=level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        format="%(asctime)s %(levelname)s %(name)s:%(lineno)d: %(message)s",
+        handlers=handlers,
+        force=True,
     )
     logging.getLogger("aiohttp.access").setLevel(logging.WARNING)
     logging.getLogger("qdarkstyle").setLevel(logging.WARNING)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,4 +1,7 @@
 import logging
+import re
+from pathlib import Path
+
 from rarapla.logging_config import setup_logging
 
 
@@ -6,3 +9,13 @@ def test_setup_logging_sets_levels() -> None:
     setup_logging(level=logging.DEBUG)
     assert logging.getLogger("qdarkstyle").level == logging.WARNING
     assert logging.getLogger("aiohttp.access").level == logging.WARNING
+
+
+def test_setup_logging_logs_to_file(tmp_path: Path) -> None:
+    log_file = tmp_path / "test.log"
+    setup_logging(level=logging.INFO, log_file=str(log_file))
+    logger = logging.getLogger("test_logger")
+    logger.info("hello")
+    contents = log_file.read_text()
+    assert "test_logger" in contents
+    assert re.search(r"test_logger:\d+: hello", contents) is not None


### PR DESCRIPTION
## Summary
- support optional log file and include line numbers in log output
- test logging to file and log format

## Testing
- `python3 -m flake8`
- `PYTHONPATH=src python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abebdf6978832983715b42689ac928